### PR TITLE
#51 Use classic METRICS_PAT for metrics action

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: lowlighter/metrics@latest
         with:
-          token: ${{ secrets.GH_STATS_PAT }}
+          token: ${{ secrets.METRICS_PAT }}
           user: AhoyLemon
           filename: stats/metrics/main.svg
           template: classic
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: lowlighter/metrics@latest
         with:
-          token: ${{ secrets.GH_STATS_PAT }}
+          token: ${{ secrets.METRICS_PAT }}
           user: AhoyLemon
           filename: stats/metrics/languages.svg
           base: ""
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: lowlighter/metrics@latest
         with:
-          token: ${{ secrets.GH_STATS_PAT }}
+          token: ${{ secrets.METRICS_PAT }}
           user: AhoyLemon
           filename: stats/metrics/isocalendar.svg
           base: ""
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: lowlighter/metrics@latest
         with:
-          token: ${{ secrets.GH_STATS_PAT }}
+          token: ${{ secrets.METRICS_PAT }}
           user: AhoyLemon
           filename: stats/metrics/habits.svg
           base: ""


### PR DESCRIPTION
Follow-up to #52. The merged workflow failed on main because lowlighter/metrics rejects fine-grained PATs for GraphQL. This switches to the new classic-scoped \`METRICS_PAT\` secret.

## Summary
- Points all four jobs in \`metrics.yml\` at \`secrets.METRICS_PAT\` instead of \`GH_STATS_PAT\`.
- \`GH_STATS_PAT\` stays in place for \`update-github-stats.yml\` (fine-grained is fine for REST/GraphQL via octokit, and keeps the tighter scoping for private repo counts).

## Test plan
- [x] Merge.
- [ ] Actions → Metrics → Run workflow.
- [ ] Verify all four jobs green and SVGs land in \`stats/metrics/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)